### PR TITLE
Refactor SleddingAPI and mod panel registration

### DIFF
--- a/SleddingEngineTweaks/API/GameAPI.cs
+++ b/SleddingEngineTweaks/API/GameAPI.cs
@@ -38,56 +38,8 @@ namespace SleddingEngineTweaks.API
 
         public void Log(string message)
         {
-            _plugin.LuaManager.OutputMessage($"[LUA]: {message}");
+            _plugin.LuaManager.OutputMessage($"[GameAPI]: {message}");
         }
-
-        public bool RegisterModPanel(string modName)
-        {
-            // Placeholder for SleddingAPI integration
-            Log($"Registered mod panel: {modName}");
-            return true;
-        }
-
-        #region Mod Panel API
-        public bool RegisterModTab(string modName, string tabName)
-        {
-            // Placeholder for SleddingAPI integration
-            Log($"Registered tab '{tabName}' for mod '{modName}'");
-            return true;
-        }
-
-        public bool RegisterLabelOption(string modName, string tabName, string optionName)
-        {
-            // Placeholder for SleddingAPI integration
-            Log($"Registered label '{optionName}' in tab '{tabName}' for mod '{modName}'");
-            return true;
-        }
-
-        public bool UpdateLabelOption(string modName, string tabName, string newText)
-        {
-            // Placeholder for SleddingAPI integration
-            Log($"Updating label in tab '{tabName}' for mod '{modName}' to '{newText}'");
-            return true;
-        }
-
-        public bool RegisterButtonOption(string modName, string tabName, string buttonText, DynValue callback)
-        {
-            // Placeholder for SleddingAPI integration
-            Log($"Registered button '{buttonText}' in tab '{tabName}' for mod '{modName}'");
-            // Example of how someone might call the Lua function:
-            // _plugin.LuaManager.CallLuaFunction(callback);
-            return true;
-        }
-
-        public bool RegisterSelectorOption(string modName, string tabName, string selectorText, bool defaultValue, DynValue callback)
-        {
-            // Placeholder for SleddingAPI integration
-            Log($"Registered selector '{selectorText}' in tab '{tabName}' for mod '{modName}'");
-            // Example of how someone might call the Lua function:
-            // _plugin.LuaManager.CallLuaFunction(callback, newValue);
-            return true;
-        }
-        #endregion
 
         #region Player API
         public GameObject GetPlayer()

--- a/SleddingEngineTweaks/API/SleddingAPI.cs
+++ b/SleddingEngineTweaks/API/SleddingAPI.cs
@@ -95,7 +95,7 @@ namespace SleddingEngineTweaks.API
 
         public SleddingAPIStatus RegisterButtonOption(string modName, string tabName, string buttonName, DynValue callback)
         {
-            if (callback == null && callback.Type != DataType.Function)
+            if (callback == null || callback.Type != DataType.Function)
             {
                 Plugin.GameAPI.Log($"{buttonName} (RegisterButtonOption) requires a valid function callback.");
                 return SleddingAPIStatus.UnknownError;

--- a/SleddingEngineTweaks/ImGuiController.cs
+++ b/SleddingEngineTweaks/ImGuiController.cs
@@ -63,7 +63,7 @@ namespace SleddingEngineTweaks
                 fontSize = 14
             };
 
-            foreach (var panel in SleddingAPI.GetAllModPanels().Values)
+            foreach (var panel in Plugin.SleddingAPI.GetAllModPanels().Values)
             {
                 panel.Render(panelStyle);
             }

--- a/SleddingEngineTweaks/Plugin.cs
+++ b/SleddingEngineTweaks/Plugin.cs
@@ -19,7 +19,8 @@ namespace SleddingEngineTweaks
         internal static ManualLogSource StaticLogger;
         private static ImGuiController _controller;
         public LuaManager LuaManager { get; private set; }
-        public GameAPI _gameAPI;
+        internal static GameAPI GameAPI;
+        internal static SleddingAPI SleddingAPI;
     
         // config
         public static ConfigEntry<Key> MasterKey;
@@ -65,13 +66,15 @@ namespace SleddingEngineTweaks
         private void RegisterGameAPI()
         {
             // Create an API object that exposes safe game functionality to Lua
-            _gameAPI = new GameAPI(this);
-            LuaManager.RegisterGlobal("game", _gameAPI);
+            GameAPI = new GameAPI(this);
+            SleddingAPI = new SleddingAPI(this);
+            LuaManager.RegisterGlobal("game", GameAPI);
+            LuaManager.RegisterGlobal("set", SleddingAPI);
         }
 
         private void OnDestroy()
         {
-            _gameAPI?.Dispose();
+            GameAPI?.Dispose();
         }
         
         public static void SavePanelPosition(string panelName, Rect position)

--- a/SleddingEngineTweaks/Plugin.cs
+++ b/SleddingEngineTweaks/Plugin.cs
@@ -75,6 +75,7 @@ namespace SleddingEngineTweaks
         private void OnDestroy()
         {
             GameAPI?.Dispose();
+            SleddingAPI?.Dispose();
         }
         
         public static void SavePanelPosition(string panelName, Rect position)

--- a/SleddingEngineTweaks/Scripting/LuaManager.cs
+++ b/SleddingEngineTweaks/Scripting/LuaManager.cs
@@ -62,6 +62,7 @@ namespace SleddingEngineTweaks.Scripting
             // GameObject, Transform, Vector3, etc., is redundant. MoonSharp handles this
             // We only need to keep custom type registrations
             UserData.RegisterType<GameAPI>();
+            UserData.RegisterType<SleddingAPI>();
             UserData.RegisterType<SleddingAPIStatus>();
             UserData.RegisterType<OptionType>();
 

--- a/SleddingEngineTweaks/UI/ModPanel.cs
+++ b/SleddingEngineTweaks/UI/ModPanel.cs
@@ -89,13 +89,13 @@ namespace SleddingEngineTweaks.UI
             return SleddingAPIStatus.ModTabNotFound;
         }
         
-        public SleddingAPIStatus UpdateOption(string tabName, string newText, OptionType optionType)
+        public SleddingAPIStatus UpdateOption(string tabName,string oldText, string newText, OptionType optionType)
         {
             foreach (ModTab tab in tabs)
             {
                 if (tab.GetName() == tabName)
                 {
-                    tab.UpdateOption(newText, optionType);
+                    tab.UpdateOption(oldText, newText, optionType);
                     return SleddingAPIStatus.Ok;
                 }
             }

--- a/SleddingEngineTweaks/UI/ModTab.cs
+++ b/SleddingEngineTweaks/UI/ModTab.cs
@@ -46,11 +46,11 @@ namespace SleddingEngineTweaks.UI
             options.Add(option);
         }
         
-        public void UpdateOption(string newText, OptionType optionType)
+        public void UpdateOption(string oldText, string newText, OptionType optionType)
         {
             foreach (var option in options)
             {
-                if (option.GetOptionType() == optionType)
+                if (option.GetName() == oldText && option.GetOptionType() == optionType)
                 {
                     option.SetName(newText);
                     break;

--- a/SleddingEngineTweaks/UI/SleddingEngineTweaksPanel/SETMain.cs
+++ b/SleddingEngineTweaks/UI/SleddingEngineTweaksPanel/SETMain.cs
@@ -22,20 +22,20 @@ namespace SleddingEngineTweaks.UI.SleddingEngineTweaksPanel
             var showOnStartOption = new ModOption_Selector("Show this UI on startup", Plugin.ShowOnStart.Value);
             showOnStartOption.ValueChanged += (value) => Plugin.ShowOnStart.Value = value;
             
-            SleddingAPI.RegisterModPanel(modName);
-
-            SleddingAPI.RegisterModTab(modName, "Options");
-            SleddingAPI.RegisterOption(modName, "Options", $"SET Version: {MyPluginInfo.PLUGIN_VERSION}", OptionType.Label);
-            SleddingAPI.RegisterOption(modName, "Options", $"Sledding Game Version: {Application.version}", OptionType.Label);
-            SleddingAPI.RegisterOption(modName, "Options", showOnStartOption);
+            Plugin.SleddingAPI.RegisterModPanel(modName);
             
-            SleddingAPI.RegisterModTab(modName, "Keybinds");
-            SleddingAPI.RegisterOption(modName, "Keybinds", masterKey);
+            Plugin.SleddingAPI.RegisterModTab(modName, "Options");
+            Plugin.SleddingAPI.RegisterLabelOption(modName, "Options", $"SET Version: {MyPluginInfo.PLUGIN_VERSION}");
+            Plugin.SleddingAPI.RegisterLabelOption(modName, "Options", $"Sledding Game Version: {Application.version}");
+            Plugin.SleddingAPI.RegisterOption(modName, "Options", showOnStartOption);
+            
+            Plugin.SleddingAPI.RegisterModTab(modName, "Keybinds");
+            Plugin.SleddingAPI.RegisterOption(modName, "Keybinds", masterKey);
             
             //SleddingAPI.RegisterModTab(modName, "Console");
-            SleddingAPI.RegisterModTab(modName, consoleTab);
-            SleddingAPI.RegisterModTab(modName, "Debug");
-            SleddingAPI.RegisterModTab(modName, "Extra");
+            Plugin.SleddingAPI.RegisterModTab(modName, consoleTab);
+            Plugin.SleddingAPI.RegisterModTab(modName, "Debug");
+            Plugin.SleddingAPI.RegisterModTab(modName, "Extra");
         }
     }
 }


### PR DESCRIPTION
Reworked SleddingAPI to be an instance class, moved mod panel and tab registration from GameAPI to SleddingAPI. Improved option update logic to require old and new text, and added label/button registration methods. Updated LuaManager and UI code to use the new API structure.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for registering button options with Lua callbacks, including error handling for invalid or failing callbacks.
  * Exposed a new API for mod developers, allowing more flexible registration and management of mod panels, tabs, and options.
  * Introduced dedicated label option registration method for clearer API usage.

* **Improvements**
  * Refined option update methods to require previous option text for more precise updates.
  * Enhanced label option registration with a dedicated method.

* **Refactor**
  * Shifted APIs from static to instance-based usage, improving modularity and future extensibility.
  * Updated API exposure to Lua, making new features accessible to script authors.
  * Centralized API instances for consistent access across the plugin.

* **Chores**
  * Updated log message prefixes for improved clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->